### PR TITLE
Add KrakenD gateway with IPAM endpoints and OpenAPI spec

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,0 +1,29 @@
+# IPAM Gateway
+
+This KrakenD configuration proxies Infoblox and exposes its IPAM API under the `/ipam` path. Clients interact with the gateway instead of contacting Infoblox directly.
+
+## Endpoints
+
+- `POST http://<gateway>/ipam/subnets` – create subnets
+- `POST http://<gateway>/ipam/zones` – create zones
+
+Requests are validated against JSON Schemas found in `schemas/`.
+
+An OpenAPI specification describing the gateway is available in `openapi.yaml`.
+
+## Configuration
+
+Set the following environment variables before starting KrakenD:
+
+- `KRAKEND_PORT` – port where KrakenD listens
+- `INFOBLOX_HOST` – Infoblox host (e.g., `infoblox.example.com`)
+- `INFOBLOX_USER` – Infoblox username
+- `INFOBLOX_PASS` – Infoblox password
+
+Run the gateway with:
+
+```sh
+krakend run -c krakend.yaml
+```
+
+Once running, clients can call `http://<gateway>/ipam/*` to access the IPAM API.

--- a/gateway/krakend.yaml
+++ b/gateway/krakend.yaml
@@ -1,0 +1,26 @@
+version: 3
+name: ipam-gateway
+port: {{ .Env.KRAKEND_PORT }}
+endpoints:
+  - endpoint: /ipam/subnets
+    method: POST
+    input_validation:
+      type: json
+      json_schema: schemas/subnet.json
+    backend:
+      - host:
+          - "https://{{ .Env.INFOBLOX_USER }}:{{ .Env.INFOBLOX_PASS }}@{{ .Env.INFOBLOX_HOST }}"
+        url_pattern: /wapi/v2.7/network
+        method: POST
+        encoding: json
+  - endpoint: /ipam/zones
+    method: POST
+    input_validation:
+      type: json
+      json_schema: schemas/zone.json
+    backend:
+      - host:
+          - "https://{{ .Env.INFOBLOX_USER }}:{{ .Env.INFOBLOX_PASS }}@{{ .Env.INFOBLOX_HOST }}"
+        url_pattern: /wapi/v2.7/zone_auth
+        method: POST
+        encoding: json

--- a/gateway/openapi.yaml
+++ b/gateway/openapi.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: IPAM Gateway
+  version: '1.0.0'
+servers:
+  - url: http://{gateway}:{port}
+    variables:
+      gateway:
+        default: localhost
+      port:
+        default: '8080'
+paths:
+  /ipam/subnets:
+    post:
+      summary: Create subnet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Subnet'
+      responses:
+        '200':
+          description: Created
+  /ipam/zones:
+    post:
+      summary: Create zone
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Zone'
+      responses:
+        '200':
+          description: Created
+components:
+  schemas:
+    Subnet:
+      $ref: './schemas/subnet.json'
+    Zone:
+      $ref: './schemas/zone.json'

--- a/gateway/schemas/subnet.json
+++ b/gateway/schemas/subnet.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "network": { "type": "string" },
+    "cidr": {
+      "type": "string",
+      "pattern": "^\\d{1,3}(\\.\\d{1,3}){3}/\\d{1,2}$"
+    }
+  },
+  "required": ["network", "cidr"],
+  "additionalProperties": false
+}

--- a/gateway/schemas/zone.json
+++ b/gateway/schemas/zone.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "fqdn": {
+      "type": "string",
+      "pattern": "^([a-zA-Z0-9_\\-]+\\.)+[A-Za-z]{2,}$"
+    }
+  },
+  "required": ["fqdn"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add KrakenD config for IPAM subnets and zones endpoints
- validate requests against JSON schemas
- provide OpenAPI spec and document how to use it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c60dca1b5c832aa6959dd98c64e5d8