### PR TITLE
docs: document plugin system and add inventory manifest

### DIFF
--- a/PluginDOC.md
+++ b/PluginDOC.md
@@ -1,0 +1,43 @@
+# Plugin System Overview
+
+This document describes the low level mechanics of the frontend plugin system.
+
+## Directory structure
+Each plugin lives under `frontend/src/lib/modules/<plugin>/` and contains:
+
+- `manifest.json` – metadata used for discovery and routing.
+- `routes/` – Svelte components implementing the plugin pages.
+- Optional supporting files such as settings modules or assets.
+
+## Manifest
+The manifest is a JSON file that declares how the host should load the plugin. Fields:
+
+| Field | Description |
+| --- | --- |
+| `name` | Unique identifier used in URLs and imports. |
+| `label` | Human friendly name for navigation. |
+| `icon` | Icon reference used in UI elements. |
+| `version` | Plugin version for compatibility checks. |
+| `permissions` | Optional array of authorization scopes. |
+| `routes` | Array of route objects defining pages exposed by the plugin. |
+
+A route object contains:
+
+- `path`: subpath mounted under the plugin base path.
+- `entry`: relative file path to the Svelte component. Components are lazy‑loaded using dynamic `import()`.
+- `nav`: optional navigation metadata (`label`, `icon`, `admin`).
+
+## Discovery and loading
+1. At startup the host scans `frontend/src/lib/modules/*/manifest.json` to build a registry of available plugins.
+2. For each manifest, the host verifies required permissions and version compatibility.
+3. Routes from all manifests are combined to build the runtime router. When the user navigates to a plugin route the corresponding component is imported on demand.
+4. Navigation components (sidebar, admin menu) read `label`/`icon` from the manifests. Routes flagged with `admin: true` are surfaced only in administration UIs.
+
+## Permissions
+If a manifest lists `permissions`, the host checks the current session. Missing scopes trigger an auth flow before the plugin becomes active.
+
+## Settings hooks
+A plugin may optionally expose a `settings.ts` module referenced from the manifest. The host loads this module when rendering plugin configuration screens.
+
+This contract keeps plugins self‑contained and discoverable while allowing the core application to control authentication, authorization and lifecycle.
+

--- a/frontend/src/lib/modules/inventory/manifest.json
+++ b/frontend/src/lib/modules/inventory/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "inventory",
+  "label": "Inventory",
+  "icon": "mdi:archive",
+  "version": "1.0.0",
+  "routes": [
+    {
+      "path": "/",
+      "entry": "./routes/+page.svelte",
+      "nav": { "label": "Inventory", "icon": "mdi:archive" }
+    },
+    {
+      "path": "/activity",
+      "entry": "./routes/activity/+page.svelte",
+      "nav": { "label": "Activity" }
+    },
+    {
+      "path": "/admin/settings",
+      "entry": "./routes/admin/settings/+page.svelte",
+      "nav": { "label": "Settings", "admin": true }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document plugin architecture in PluginDOC
- add manifest for inventory module with route metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c73fa64308832aba9639fee9ad9e2d