### PR TITLE
feat: lazy load plugin pages

### DIFF
--- a/frontend/src/lib/PluginLink.svelte
+++ b/frontend/src/lib/PluginLink.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { SideNavLink } from 'carbon-components-svelte';
+  import { goto } from '$app/navigation';
+  let { mod } = $props<{ mod: string }>();
+  const handleClick = async (event: MouseEvent) => {
+    event.preventDefault();
+    await import(`../routes/${mod}/+page.svelte`);
+    goto(`/${mod}`);
+  };
+</script>
+
+<SideNavLink href={`/${mod}`} on:click={handleClick}>{mod}</SideNavLink>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
   import UserAvatar from 'carbon-icons-svelte/lib/UserAvatarFilledAlt.svelte';
   import { login } from '$lib/auth';
   import modules from '$lib/modules.json';
+  import PluginLink from '$lib/PluginLink.svelte';
 
   let { children } = $props();
   let switcherOpen = $state(false);
@@ -48,7 +49,7 @@
 <SideNav fixed isOpen={true} aria-label="Sidebar">
   <SideNavItems>
     {#each modules as mod}
-      <SideNavLink href={`/${mod}`}>{mod}</SideNavLink>
+      <PluginLink mod={mod} />
     {/each}
     <SideNavLink href="/admin">Admin</SideNavLink>
   </SideNavItems>


### PR DESCRIPTION
## Summary
- load plugin root pages on demand via new `PluginLink` component
- use `PluginLink` in app layout to resolve module routes dynamically

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `npm run build`
- `curl -I http://localhost:4174/`
- `curl -I http://localhost:4174/inventory`


------
https://chatgpt.com/codex/tasks/task_e_68c7464bbad8832ab4c77274f5c8d216