### PR TITLE
feat: add plugin registry

### DIFF
--- a/frontend/src/lib/modules.json
+++ b/frontend/src/lib/modules.json
@@ -1,3 +1,0 @@
-[
-  "inventory"
-]

--- a/frontend/src/lib/pluginRegistry.test.ts
+++ b/frontend/src/lib/pluginRegistry.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+
+const { getPlugins } = await import('./pluginRegistry');
+
+describe('plugin registry', () => {
+  it('exposes plugin manifests', () => {
+    const plugins = getPlugins();
+    const inventory = plugins.find((p) => p.name === 'inventory');
+    expect(inventory).toBeDefined();
+    expect(inventory?.label).toBe('Inventory');
+  });
+});

--- a/frontend/src/lib/pluginRegistry.ts
+++ b/frontend/src/lib/pluginRegistry.ts
@@ -1,0 +1,24 @@
+export interface PluginManifest {
+  name: string;
+  label: string;
+  icon: string;
+  version: string;
+  routes: Array<{
+    path: string;
+    entry: string;
+    nav?: {
+      label: string;
+      icon?: string;
+      admin?: boolean;
+    };
+  }>;
+}
+
+const manifests = import.meta.glob<PluginManifest>(
+  '/src/lib/modules/*/manifest.json',
+  { eager: true, import: 'default' }
+);
+
+export function getPlugins(): PluginManifest[] {
+  return Object.values(manifests);
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -14,9 +14,10 @@
   import Switcher from 'carbon-icons-svelte/lib/Switcher.svelte';
   import UserAvatar from 'carbon-icons-svelte/lib/UserAvatarFilledAlt.svelte';
   import { login } from '$lib/auth';
-  import modules from '$lib/modules.json';
+  import { getPlugins } from '$lib/pluginRegistry';
   import PluginLink from '$lib/PluginLink.svelte';
 
+  const plugins = getPlugins();
   let { children } = $props();
   let switcherOpen = $state(false);
 
@@ -48,8 +49,8 @@
 
 <SideNav fixed isOpen={true} aria-label="Sidebar">
   <SideNavItems>
-    {#each modules as mod}
-      <PluginLink mod={mod} />
+    {#each plugins as plugin}
+      <PluginLink mod={plugin.name} />
     {/each}
     <SideNavLink href="/admin">Admin</SideNavLink>
   </SideNavItems>


### PR DESCRIPTION
## Summary
- make plugin registry type-safe by importing manifest default
- update layout to use plugins from registry
- add unit test covering plugin registry

## Testing
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c74bd49650832a81eaf2ef3cbaf0e7