### PR TITLE
feat: add admin dashboard

### DIFF
--- a/frontend/src/lib/admin.test.ts
+++ b/frontend/src/lib/admin.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getAdminPlugins, toAdminPath } from './admin';
+
+describe('admin utilities', () => {
+  it('returns only plugins with admin routes', () => {
+    const plugins = getAdminPlugins();
+    expect(plugins).toHaveLength(1);
+    const inventory = plugins[0];
+    expect(inventory.name).toBe('inventory');
+    expect(inventory.adminRoutes).toHaveLength(1);
+    expect(inventory.adminRoutes[0].path).toBe('/admin/settings');
+  });
+
+  it('builds admin paths', () => {
+    expect(toAdminPath('inventory', '/admin/settings')).toBe(
+      '/admin/inventory/settings'
+    );
+  });
+});

--- a/frontend/src/lib/admin.ts
+++ b/frontend/src/lib/admin.ts
@@ -1,0 +1,19 @@
+import { getPlugins } from './pluginRegistry';
+import type { PluginManifest } from './pluginRegistry';
+
+export interface AdminPlugin extends PluginManifest {
+  adminRoutes: PluginManifest['routes'];
+}
+
+export function getAdminPlugins(): AdminPlugin[] {
+  return getPlugins()
+    .map((plugin) => ({
+      ...plugin,
+      adminRoutes: plugin.routes.filter((r) => r.nav?.admin),
+    }))
+    .filter((p) => p.adminRoutes.length > 0);
+}
+
+export function toAdminPath(plugin: string, path: string): string {
+  return `/admin/${plugin}${path.replace(/^\/admin/, '')}`;
+}

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -1,1 +1,24 @@
+<script lang="ts">
+  import { getAdminPlugins, toAdminPath } from '$lib/admin';
+
+  const plugins = getAdminPlugins();
+</script>
+
 <h1>Admin Area</h1>
+
+{#if plugins.length === 0}
+  <p>No admin modules available.</p>
+{:else}
+  {#each plugins as p}
+    <section>
+      <h2>{p.label}</h2>
+      <ul>
+        {#each p.adminRoutes as route}
+          <li>
+            <a href={toAdminPath(p.name, route.path)}>{route.nav?.label ?? route.path}</a>
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/each}
+{/if}


### PR DESCRIPTION
## Summary
- extract shared admin utilities for filtering plugin admin routes and building admin URLs
- refactor admin page to use new utilities
- cover admin utilities with unit tests

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c751c0179c832aa435c326b5f485b4